### PR TITLE
Ghc710support

### DIFF
--- a/hs-carbon.cabal
+++ b/hs-carbon.cabal
@@ -1,6 +1,6 @@
 
 name:                hs-carbon
-version:             0.1.0.0
+version:             0.1.1.0
 synopsis:            A Haskell framework for parallel monte carlo simulations
 description:
   Carbon is an open-source, Haskell framework aiming to provide easy access to

--- a/src/Data/Result.hs
+++ b/src/Data/Result.hs
@@ -9,7 +9,6 @@ module Data.Result
 where
 
 import Control.DeepSeq
-import Data.Monoid
 
 {- $description #description#
 Carbon simulations are built up from 'Control.Monad.MonteCarlo' actions.

--- a/src/Data/Summary/Bool.hs
+++ b/src/Data/Summary/Bool.hs
@@ -15,7 +15,7 @@ data BoolSumm = BoolSumm {
                 , _noTotal   :: !Int
                 } deriving (Show)
 
-instance NFData BoolSumm
+instance NFData BoolSumm where rnf x = seq x ()
 
 boolSumm :: [Bool] -> BoolSumm
 boolSumm = foldl' addObs rzero

--- a/src/Data/Summary/Double.hs
+++ b/src/Data/Summary/Double.hs
@@ -15,7 +15,7 @@ data DoubleSumm = DoubleSumm {
                   , _size :: !Int
 } deriving (Show)
 
-instance NFData DoubleSumm
+instance NFData DoubleSumm where rnf x = seq x ()
 
 doubleSumm :: [Double] -> DoubleSumm
 doubleSumm = foldl' addObs rzero


### PR DESCRIPTION
This branch adds support for GHC 7.10.

I simply followed the instructions at https://ghc.haskell.org/trac/ghc/wiki/Migration/7.10. 
